### PR TITLE
:star: Add feature to allow configuring maxDaysToShow for each calendar

### DIFF
--- a/docs/options/entity-options.md
+++ b/docs/options/entity-options.md
@@ -15,6 +15,7 @@ nav_order: 2
 | icon            | string | v2.0.0 | `null` Add an icon to a calendar                                                                       |
 | startTimeFilter | string | v2.0.0 | Only shows events between specific times _NOTE_ must be set with `endTimeFilter` format: `'10:00'`     |
 | endTimeFilter   | string | v2.0.0 | Only shows events between specific times _NOTE_ must be set with `startTimeFilter` format: `'17:00'`   |
+| maxDaysToShow   | integer | v5.2.0  | `7` Maximum number of days to show. Overrides main configuration maxDaysToShow for this calendar     |                                                                                                                         |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "atomic-calendar-revive",
-	"version": "5.1.0",
+	"version": "5.2.0",
 	"editor_version": "1.7.0",
 	"description": "Calendar Card for Home Assistant",
 	"main": "atomic-calendar-revive.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1108,7 +1108,15 @@ class AtomicCalendarRevive extends LitElement {
 			.add(timeOffset, 'minutes').format('YYYY-MM-DDTHH:mm:ss');
 		const calendarUrlList: string[] = [];
 		this._config.entities.map((entity) => {
-			calendarUrlList.push(`calendars/${entity.entity}?start=${start}Z&end=${end}Z`);
+			if(typeof entity.maxDaysToShow != 'undefined') {
+				const altEnd = dayjs()
+						.add(entity.maxDaysToShow! - 1 + this._config.startDaysAhead!, 'day')
+						.endOf('day')
+						.add(timeOffset, 'minutes').format('YYYY-MM-DDTHH:mm:ss');
+				calendarUrlList.push(`calendars/${entity.entity}?start=${start}Z&end=${altEnd}Z`);
+			} else {
+				calendarUrlList.push(`calendars/${entity.entity}?start=${start}Z&end=${end}Z`);
+			}
 		});
 
 		// call to API for events


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

## Description
Add feature to allow configuring maxDaysToShow by entity.

This allows users to override the general maxDaysToShow configuration on specific calendars. 

## Related issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!--- Please link to the issue here. -->
Closes #517 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? What additions does it bring? -->
Users may want variable maxDaysToShow to support different calendar use cases. Example: users might want to show a month worth of events from their Birthdays calendar, but only the next week for appointments. Previously, something similar could be accomplished with the max_events setting in the Google calendar integration, but it was removed.

## How has this been tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of the tests you ran. -->
Installed locally and tried different combinations of maxDaysToShow at the main config level and also for multiple entities. Tried both overriding with longer and shorter time periods.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Docs change / refactoring.
- [x] Non-breaking change (fix or feature that wouldn't cause existing functionality to change/break).
- [] Breaking change (fix or feature that would cause existing functionality to change/break).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have performed a self-review of my own code.
- [] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [] My changes don't generate new warnings.
- [x] I have read the [CONTRIBUTING](https://github.com/marksie1988/.github/blob/master/docs/CONTRIBUTING.md) document.
- [] I have added tests that prove my fix is effective or that my feature works.
- [] All new and existing tests pass.
